### PR TITLE
Fix/register

### DIFF
--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -6,18 +6,30 @@ import { useUser } from '../../context/UserContext';
 import { useNavigate } from 'react-router-dom';
 
 export default function Auth({ isRegistering = false }) {
-  const { formState, formMessage, handleFormChange, setFormMessage } =
-    useForm();
+  const { formState, formMessage, handleFormChange, setFormMessage } = useForm({
+    username: '',
+    password: '',
+  });
   const navigate = useNavigate();
   const { currentUser, setCurrentUser } = useUser();
+
+  const onlyLettersAndNumbers = (str) => {
+    return /[A-Za-z0-9]g/.test(str);
+  };
 
   const handleAuthSubmit = async (e) => {
     e.preventDefault();
     if (isRegistering) {
-      const user = await registerUser(formState.username, formState.password);
-      if (user?.username) {
+      if (!onlyLettersAndNumbers(formState.username)) {
+        setFormMessage('usernames can only contain lettes and numbers');
+      } else if (user?.username) {
+        const user = await registerUser(formState.username, formState.password);
         setFormMessage('you are registered');
         navigate(`/signin`, { push: true });
+      } else if (user.message === 'username already exists') {
+        setFormMessage(
+          'that username is already taken. please choose a different username.'
+        );
       }
     } else {
       const { message } = await signInUser(
@@ -47,7 +59,7 @@ export default function Auth({ isRegistering = false }) {
       <label>
         Password:
         <input
-          type="text"
+          type="password"
           name="password"
           value={formState.password}
           onChange={(e) => handleFormChange(e)}

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useUser } from '../../context/UserContext';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { logOutUser } from '../../services/users';
+import styles from './Layout.css';
 
 export default function Header() {
   // get username from context (or whereever user is stored)
@@ -21,7 +22,14 @@ export default function Header() {
       {!currentUser.username && <NavLink to="/signin">Sign In</NavLink>}
       {/* // pass user into path as template literals to access the logged in users
       //profile. */}
-      <NavLink to={`/user/${currentUser.username}`}>Profile</NavLink>
+      {currentUser.username && (
+        <div className={styles.loggedIn}>
+          <p>Signed In As:</p>
+          <NavLink to={`/user/${currentUser.username}`}>
+            {currentUser.username}
+          </NavLink>
+        </div>
+      )}
       {currentUser.username && <button onClick={handleLogout}>Log Out</button>}
     </header>
   );

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { useUser } from '../../context/UserContext';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { logOutUser } from '../../services/users';
 
 export default function Header() {
   // get username from context (or whereever user is stored)
   const { currentUser, setCurrentUser } = useUser();
+  const navigate = useNavigate();
 
   const handleLogout = async () => {
     await logOutUser();
     setCurrentUser({});
+    navigate(`/`, { push: true });
   };
 
   return (

--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -67,3 +67,18 @@ header button:hover,
 footer a:hover {
   color: aqua;
 }
+
+.loggedIn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loggedIn p {
+  color: #5448a7;
+  font-weight: 500;
+}
+
+.loggedIn:hover p {
+  color: black;
+}

--- a/src/components/ProfileForm/ProfileForm.jsx
+++ b/src/components/ProfileForm/ProfileForm.jsx
@@ -7,8 +7,10 @@ import { useUser } from '../../context/UserContext';
 export default function ProfileForm({ isEditing = false }) {
   // TODO: REFACTOR THIS STATE INTO THE VIEW COMPONENT?
   // pass down to form as props?
-  const { formState, formMessage, handleFormChange, setFormMessage } =
-    useForm();
+  const { formState, formMessage, handleFormChange, setFormMessage } = useForm({
+    bio: '',
+    avatar: '',
+  });
   const navigate = useNavigate();
   const { currentUser } = useUser();
 

--- a/src/services/users.js
+++ b/src/services/users.js
@@ -5,6 +5,7 @@ const getUser = async () => {
         'Content-Type': 'application/json',
       },
       credentials: 'include',
+      mode: 'cors',
     });
     return await resp.json();
   } catch (error) {

--- a/src/views/Home/Canvas.jsx
+++ b/src/views/Home/Canvas.jsx
@@ -1,0 +1,3 @@
+export default function Canvas({ children }) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
- got rid of the 'Warning' for uncontrolled inputs for Auth Form
- got rid of the 'Warning' for uncontrolled inputs for Create/Edit Profile Form (where useForm was called, we needed to pass in an object with empty strings for each input value that was going to be defined)
changed the password input type to password, so passwords are not shown.
- lets the user know if the username has been taken already
- lets the user know the username they type contains characters that are not allowed in usernames
    - see Auth.jsx - line 16 - a function called onlyLettersAndNumbers
    - does not register the user until the user has a valid username
- logout redirects the user to the home page
- The logged in username is displayed in the header
- the username in the header is now the link to the logged in users profile

Note: profiles is not working at all from this branch
Note: cors response errors sometimes happened for getUser() and logOut user (i think we fixed these things somewhere else)