### PR TITLE
Audio and channel functionality improvements

### DIFF
--- a/src/components/Channel/Channel.jsx
+++ b/src/components/Channel/Channel.jsx
@@ -40,7 +40,7 @@ export default function Channel({ channel }) {
     }
   });
 
-  const { handleUpdateChannel } = useProject();
+  const { handleDeleteChannel, handleUpdateChannel } = useProject();
 
   const channelId = channel.id;
 
@@ -55,6 +55,10 @@ export default function Channel({ channel }) {
     };
     handleUpdateChannel(channelObj);
   }, [instrument, oscillator, volume, notes, fx]);
+
+  const deleteChannel = () => {
+    handleDeleteChannel(channelId);
+  };
 
   const highlightCurrentStep = (stepIndex) => {
     const sequence = document
@@ -126,6 +130,7 @@ export default function Channel({ channel }) {
           setDelay,
         }}
       />
+      <button onClick={deleteChannel}>Delete Channel</button>
     </div>
   );
 }

--- a/src/components/Channel/Channel.jsx
+++ b/src/components/Channel/Channel.jsx
@@ -11,24 +11,34 @@ import {
 import classNames from 'classnames';
 import styles from './Channel.css';
 import Row from './Row';
-import Dropdown from './Dropdown';
 import Controls from './Controls';
-import { BitCrusher } from 'tone';
 
 export default function Channel({ channel }) {
   const [instrument, setInstrument] = useState(channel.type);
-  const [oscillator, setOscillator] = useState(channel.osc);
+  const [oscillator, setOscillator] = useState(channel.osc); // TODO: add buttons for monoSynth?
   const [volume, setVolume] = useState(channel.volume);
-  const [keyArray, setKeyArray] = useState(keyCMajorPentatonic4);
   const [notes, setNotes] = useState(channel.steps);
   const [fx, setFx] = useState({
     reverb: channel.reverb,
+    bitcrusher: 0,
+    delay: 0,
   });
 
-  const [fx1, setFx1] = useState(0);
-  const [fx2, setFx2] = useState(0);
-  const [attack, setAttack] = useState(0.1);
-  const [release, setRelease] = useState(0.1);
+  const [bitcrusher, setBitcrusher] = useState(0);
+  const [delay, setDelay] = useState(0);
+
+  const [keyArray, setKeyArray] = useState(() => {
+    switch (instrument) {
+      case 'duoSynth':
+        return keyCMajorPentatonic4;
+      case 'monoSynth':
+        return keyCMajorPentatonic3;
+      case 'membraneSynth':
+        return keyCMajorPentatonic2;
+      default:
+        return keyCMajorPentatonic4;
+    }
+  });
 
   const { handleUpdateChannel } = useProject();
 
@@ -94,41 +104,28 @@ export default function Channel({ channel }) {
       >
         <Instrument
           type={instrument}
-          envelope={{ attack, release }}
-          oscillator={{ type: oscillator }}
+          oscillator={{ type: 'triangle' }}
+          envelope={{ attack: 0.1, release: 0.1 }}
         />
-        <Effect type="bitCrusher" wet={fx1} />
-        <Effect type="feedbackDelay" wet={fx2} />
+        <Effect type="bitCrusher" wet={bitcrusher} />
+        <Effect type="feedbackDelay" wet={delay} />
         <Effect type="freeverb" wet={fx.reverb} />
       </Track>
       {/* Display components below*/}
       <Row {...{ notes, handleNoteChange }} />
-      <Dropdown {...{ instrument, setInstrument, oscillator, setOscillator }} />
-      <Controls {...{ channelId, volume, setVolume, fx, setFx }} />
-      <div>
-        <label>
-          fx1
-          <input
-            type="range"
-            min="0.0"
-            max="1"
-            step="0.05"
-            onChange={(e) => setFx1(e.target.value)}
-            value={fx1}
-          />
-        </label>
-        <label>
-          fx2
-          <input
-            type="range"
-            min="0.0"
-            max="1"
-            step="0.05"
-            onChange={(e) => setFx2(e.target.value)}
-            value={fx2}
-          />
-        </label>
-      </div>
+      <Controls
+        {...{
+          channelId,
+          volume,
+          setVolume,
+          fx,
+          setFx,
+          bitcrusher,
+          setBitcrusher,
+          delay,
+          setDelay,
+        }}
+      />
     </div>
   );
 }

--- a/src/components/Channel/Channel.jsx
+++ b/src/components/Channel/Channel.jsx
@@ -1,23 +1,34 @@
 import { useState, useEffect } from 'react';
 import { Track, Instrument, Effect } from 'reactronica';
 import { useProject } from '../../context/ProjectContext';
-import { keyCMajorPentatonic, setPitchColor } from '../../utils/toneUtils';
+import {
+  keyCMajorPentatonic2,
+  keyCMajorPentatonic3,
+  keyCMajorPentatonic4,
+  setPitchColor,
+} from '../../utils/toneUtils';
 
 import classNames from 'classnames';
 import styles from './Channel.css';
 import Row from './Row';
 import Dropdown from './Dropdown';
 import Controls from './Controls';
+import { BitCrusher } from 'tone';
 
 export default function Channel({ channel }) {
   const [instrument, setInstrument] = useState(channel.type);
   const [oscillator, setOscillator] = useState(channel.osc);
   const [volume, setVolume] = useState(channel.volume);
-  const [keyArray, setKeyArray] = useState(keyCMajorPentatonic);
+  const [keyArray, setKeyArray] = useState(keyCMajorPentatonic4);
   const [notes, setNotes] = useState(channel.steps);
   const [fx, setFx] = useState({
     reverb: channel.reverb,
   });
+
+  const [fx1, setFx1] = useState(0);
+  const [fx2, setFx2] = useState(0);
+  const [attack, setAttack] = useState(0.1);
+  const [release, setRelease] = useState(0.1);
 
   const { handleUpdateChannel } = useProject();
 
@@ -83,16 +94,41 @@ export default function Channel({ channel }) {
       >
         <Instrument
           type={instrument}
-          envelope={{ attack: 0.2, release: 0.5 }}
+          envelope={{ attack, release }}
           oscillator={{ type: oscillator }}
         />
+        <Effect type="bitCrusher" wet={fx1} />
+        <Effect type="feedbackDelay" wet={fx2} />
         <Effect type="freeverb" wet={fx.reverb} />
       </Track>
-
       {/* Display components below*/}
       <Row {...{ notes, handleNoteChange }} />
       <Dropdown {...{ instrument, setInstrument, oscillator, setOscillator }} />
       <Controls {...{ channelId, volume, setVolume, fx, setFx }} />
+      <div>
+        <label>
+          fx1
+          <input
+            type="range"
+            min="0.0"
+            max="1"
+            step="0.05"
+            onChange={(e) => setFx1(e.target.value)}
+            value={fx1}
+          />
+        </label>
+        <label>
+          fx2
+          <input
+            type="range"
+            min="0.0"
+            max="1"
+            step="0.05"
+            onChange={(e) => setFx2(e.target.value)}
+            value={fx2}
+          />
+        </label>
+      </div>
     </div>
   );
 }

--- a/src/components/Channel/Controls.jsx
+++ b/src/components/Channel/Controls.jsx
@@ -1,6 +1,17 @@
 import styles from './Channel.css';
 
-export default function Controls({ channelId, volume, setVolume, fx, setFx }) {
+export default function Controls({
+  channelId,
+  volume,
+  setVolume,
+  fx,
+  setFx,
+  bitcrusher,
+  setBitcrusher,
+  delay,
+  setDelay,
+  setKeyArray,
+}) {
   // controls for each channel
   return (
     <div className={styles.controls}>
@@ -27,6 +38,32 @@ export default function Controls({ channelId, volume, setVolume, fx, setFx }) {
           step="0.05"
           onChange={(e) => setFx({ ...fx, reverb: e.target.value })}
           value={fx.reverb}
+        />
+      </label>
+      <label>
+        Bit Crusher
+        <input
+          id={`channel-${channelId}-bitcrusher`}
+          name={`channel-${channelId}-bitcrusher`}
+          type="range"
+          min="0.0"
+          max="1"
+          step="0.05"
+          onChange={(e) => setBitcrusher(e.target.value)}
+          value={bitcrusher}
+        />
+      </label>
+      <label>
+        Delay
+        <input
+          id={`channel-${channelId}-delay`}
+          name={`channel-${channelId}-delay`}
+          type="range"
+          min="0.0"
+          max="1"
+          step="0.05"
+          onChange={(e) => setDelay(e.target.value)}
+          value={delay}
         />
       </label>
     </div>

--- a/src/components/Channel/Controls.jsx
+++ b/src/components/Channel/Controls.jsx
@@ -23,7 +23,7 @@ export default function Controls({ channelId, volume, setVolume, fx, setFx }) {
           name={`channel-${channelId}-reverb`}
           type="range"
           min="0"
-          max="1"
+          max="0.75"
           step="0.05"
           onChange={(e) => setFx({ ...fx, reverb: e.target.value })}
           value={fx.reverb}

--- a/src/components/Channel/Dropdown.jsx
+++ b/src/components/Channel/Dropdown.jsx
@@ -1,49 +1,19 @@
-import { oscillators, instruments } from '../../utils/toneUtils';
+import { instruments } from '../../utils/toneUtils';
 import styles from './Channel.css';
+import {
+  keyCMajorPentatonic2,
+  keyCMajorPentatonic3,
+  keyCMajorPentatonic4,
+} from '../../utils/toneUtils';
 
-export default function Dropdown({
-  handleAddChannel,
-  instrument,
-  setInstrument,
-  oscillator,
-  setOscillator,
-}) {
-  if (!handleAddChannel) {
-    return (
-      <div className={styles.container}>
-        <select
-          className={styles.dropdown}
-          defaultValue={instrument}
-          onChange={(e) => setInstrument(e.target.value)}
-        >
-          {instruments.map((synth) => (
-            <option key={synth} value={synth}>
-              {synth}
-            </option>
-          ))}
-        </select>
-        <select
-          className={styles.dropdown}
-          defaultValue={oscillator}
-          onChange={(e) => setOscillator(e.target.value)}
-        >
-          {oscillators.map((type) => (
-            <option key={type} value={type}>
-              {type}
-            </option>
-          ))}
-        </select>
-      </div>
-    );
-  } else {
-    return (
-      <select onChange={handleAddChannel}>
-        {instruments.map((synth) => (
-          <option key={synth} value={synth}>
-            {synth}
-          </option>
-        ))}
-      </select>
-    );
-  }
+export default function Dropdown({ handleAddChannel }) {
+  return (
+    <select onChange={handleAddChannel}>
+      {instruments.map((synth) => (
+        <option key={synth} value={synth}>
+          {synth}
+        </option>
+      ))}
+    </select>
+  );
 }

--- a/src/components/Controls/GlobalControls.jsx
+++ b/src/components/Controls/GlobalControls.jsx
@@ -17,7 +17,7 @@ export default function GlobalControls({ start, setStart }) {
         Project Volume
         <input
           type="range"
-          min="-40"
+          min="-48"
           max="0"
           value={project.volume}
           onChange={(e) => handleProjectVolume(e)}

--- a/src/context/ProjectContext.jsx
+++ b/src/context/ProjectContext.jsx
@@ -38,6 +38,8 @@ function projectReducer(project, action) {
       return { ...project, bpm: Number(action.value) };
     case 'add new channel':
       return { ...project, channels: [...project.channels, action.value] };
+    case 'delete channel':
+      return { ...project, channels: action.value };
     case 'update channels':
       return { ...project, channels: action.value };
     case 'update project title':
@@ -109,6 +111,16 @@ const ProjectProvider = ({ children }) => {
     setAddingChannel(false);
   };
 
+  const handleDeleteChannel = (channelId) => {
+    const newChannelArray = channelArray.filter((item) => {
+      if (item.id !== channelId) {
+        return item;
+      }
+    });
+    setChannelArray(newChannelArray);
+    dispatch({ type: 'delete channel', value: newChannelArray });
+  };
+
   // updates channel array
   const handleUpdateChannel = (channel) => {
     const newChannelArray = channelArray.map((item) => {
@@ -131,8 +143,9 @@ const ProjectProvider = ({ children }) => {
     project: { isLoading, addingChannel, setAddingChannel, project },
     handleProjectVolume,
     handleSongBPM,
-    handleUpdateChannel,
     handleAddChannel,
+    handleDeleteChannel,
+    handleUpdateChannel,
     handleTitleChange,
   };
 

--- a/src/context/ProjectContext.jsx
+++ b/src/context/ProjectContext.jsx
@@ -7,6 +7,11 @@ import {
 } from 'react';
 import { useParams } from 'react-router-dom';
 import { findProjectById } from '../services/project';
+import {
+  keyCMajorPentatonic2,
+  keyCMajorPentatonic3,
+  keyCMajorPentatonic4,
+} from '../utils/toneUtils';
 
 const initialState = {
   userId: 1, // TODO: replace with userId from UserContext

--- a/src/utils/toneUtils.js
+++ b/src/utils/toneUtils.js
@@ -1,11 +1,14 @@
 // global data for sequencer
 import styles from '../components/Channel/Channel.css';
 
-const keyCMajorPentatonic = ['C3', 'D3', 'E3', 'G3', 'A3', 'C4'];
+const keyCMajorPentatonic4 = ['C4', 'D4', 'E4', 'G4', 'A4', 'C5'];
+
+const keyCMajorPentatonic3 = ['C3', 'D3', 'E3', 'G3', 'A3', 'C4'];
+const keyCMajorPentatonic2 = ['C2', 'D2', 'E2', 'G2', 'A2', 'C3'];
 
 const oscillators = ['triangle', 'sine', 'square'];
 
-const instruments = ['', 'duoSynth', 'membraneSynth', 'monoSynth', 'synth'];
+const instruments = ['', 'duoSynth', 'membraneSynth', 'monoSynth'];
 
 const setPitchColor = (string) => {
   return {
@@ -17,4 +20,11 @@ const setPitchColor = (string) => {
   };
 };
 
-export { keyCMajorPentatonic, oscillators, instruments, setPitchColor };
+export {
+  keyCMajorPentatonic2,
+  keyCMajorPentatonic3,
+  keyCMajorPentatonic4,
+  oscillators,
+  instruments,
+  setPitchColor,
+};


### PR DESCRIPTION
Included are updates to the audio quality and functionality, including:

- Limiting available instruments to selected octaves and oscillator types/waveforms
  - Reduced the `Dropdown` component's need to manage conditional rendering; the user can set the instrument type when adding a new channel, but can no longer change the instrument type on an existing channel. This favors each instrument being able to play only from a selected set of notes that work well with the instrument's type.
- Additional per-channel FX: Bit Crusher and Feedback Delay, including controls for each. 
  - _Note_: These settings are _not_ saved in backend at this time and are unaffected by Save/Load project
- Delete channel functionality


![Screenshot 2022-04-21 155127](https://user-images.githubusercontent.com/32883553/164565158-0b2fc23b-405d-4a70-b290-ac2b570a4670.png)

