### PR TITLE
Add scrolling to profile page when profile image is vertical

### DIFF
--- a/src/components/Layout/Layout.css
+++ b/src/components/Layout/Layout.css
@@ -1,8 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;800&family=Major+Mono+Display&display=swap');
 
-/* font-family: 'Barlow', sans-serif; */
-/* font-family: 'Major Mono Display', monospace; */
-
 :root {
   --pink: #fe5ca7ff;
   --purple: #6e60b6ff;
@@ -59,7 +56,6 @@ header {
   justify-content: space-evenly;
   background-color: var(--purple);
   width: 100vw;
-  /* font-size: 25px; */
 }
 
 header a,

--- a/src/views/Explore/Explore.css
+++ b/src/views/Explore/Explore.css
@@ -36,7 +36,6 @@
   align-items: center;
   justify-content: space-around;
   gap: 10px;
-  /* background-color: var(--purple); */
   border-radius: 10px;
   overflow: auto;
   font-size: 1.5em;

--- a/src/views/Home/Home.css
+++ b/src/views/Home/Home.css
@@ -14,9 +14,6 @@
 
 .homeContainer p {
   font-size: 25px;
-  /* display: flex;
-  align-items: center;
-  justify-content: center; */
 }
 
 .homeBanner img:first-child {

--- a/src/views/Profile/Profile.css
+++ b/src/views/Profile/Profile.css
@@ -1,3 +1,5 @@
+/* ======== CREATE A PROFILE ============ */
+
 .createProfile {
   display: flex;
   flex-direction: column;
@@ -23,7 +25,7 @@
   filter: drop-shadow(0 0.2rem 0.25rem var(--pink));
 }
 
-/* === */
+/* ======== PROFILE CREATED ============ */
 
 .cont {
   height: 100%;
@@ -35,6 +37,13 @@
   margin-bottom: 40px;
 }
 
+.topSection {
+  display: flex;
+  justify-content: space-between;
+  margin: 20px;
+  align-items: flex-start;
+}
+
 .userProfile {
   display: flex;
   flex-direction: column;
@@ -43,25 +52,39 @@
   gap: 10px;
 }
 
-.topSection {
-  display: flex;
-  justify-content: space-between;
-  margin: 20px;
-  align-items: flex-start;
-}
-
 .profileCont {
   border: var(--white-ish) 1px solid;
+  height: 25vh;
+  overflow-y: scroll;
   border-radius: 5px;
   align-self: flex-start;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   gap: 10px;
   width: 300px;
   padding: 5px;
   margin: 40px;
+}
+
+.profileCont::-webkit-scrollbar {
+  width: 1em;
+}
+
+.profileCont::-webkit-scrollbar-track {
+  box-shadow: inset 0 0 6px var(--black-ish);
+}
+
+.profileCont::-webkit-scrollbar-thumb {
+  background: linear-gradient(
+    45deg,
+    var(--pink),
+    var(--pennyroyal),
+    var(--purple),
+    var(--aqua)
+  );
+  border-radius: 50px;
 }
 
 .userProfile h2 {
@@ -88,15 +111,12 @@
 
 .editProfButton button:hover {
   cursor: pointer;
-  /* border-radius: 5px; */
   filter: invert(100%);
 }
 
 .cont button {
   cursor: pointer;
   padding: 5px;
-  /* margin: 3px; */
-  /* background-color: var(--white-ish); */
 }
 
 .cont button:hover {
@@ -160,7 +180,6 @@
   align-items: center;
   justify-content: space-around;
   gap: 10px;
-  /* background-color: var(--purple); */
   border-radius: 10px;
   overflow: auto;
 }

--- a/src/views/Project/Project.css
+++ b/src/views/Project/Project.css
@@ -1,19 +1,15 @@
 .currentProject {
-  /* border: 2px solid red; */
   display: flex;
   box-sizing: border-box;
-  /* flex-direction: column; */
   align-items: flex-end;
   justify-content: center;
   height: 100%;
   width: 100vw;
-  /* overflow: auto; */
   margin-bottom: 40px;
   overflow-y: hidden;
 }
 
 .fixedProject {
-  /* border: blue solid 20px; */
   display: flex;
   box-sizing: border-box;
   flex-direction: column;
@@ -49,7 +45,6 @@
 }
 
 .sequencerContainer {
-  /* border: orange solid 3px; */
   padding: 15px;
   margin-top: 20px;
   border-radius: 10px;


### PR DESCRIPTION
Our profile page wasn't rendering correctly if a user submitted a vertical image (we had only submitted horizontal and square images). The deployed site looked like this: 

![Screen Shot 2022-04-21 at 9 04 45 PM](https://user-images.githubusercontent.com/69729289/164601059-a0e90052-b303-4186-a5be-55f68e420d61.png)

I updated the code so that a user can submit either a horizontal or a vertical image, and it will be contained by this border. Because of the overflow, I also added our beautiful rainbow scroll. Please take a look! 

![Screen Shot 2022-04-21 at 9 13 59 PM](https://user-images.githubusercontent.com/69729289/164601390-b41b0463-77a8-4077-84e6-8c58e8af0251.png)

