### PR TITLE
Allow users to view readonly projects without authentication (FE+BE)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,9 +58,7 @@ export default function App() {
                 path="/project/:id"
                 element={
                   <ProjectProvider>
-                    <PrivateRoute>
-                      <Project />
-                    </PrivateRoute>
+                    <Project />
                   </ProjectProvider>
                 }
               />


### PR DESCRIPTION
A quick fix for making it easier to demo the app via the `Explore` page. Requires changes from https://github.com/geo-tone/geo-tone-backend/pull/22.